### PR TITLE
fix compiler warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,60 @@
+name: Build binaries
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache
+        id: cache-1
+        uses: actions/cache@v2
+        with:
+          path: cache
+          key: ${{ runner.os }}-cache-1
+
+      - name: Download devkitPPC r37, libogc, general-tools and others
+        if: steps.cache-1.outputs.cache-hit != 'true'
+        run: | 
+          mkdir cache && cd cache
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/devkitPPC-r37-4-linux.pkg.tar.xz"
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/libogc-2.1.0-1-any.pkg.tar.xz"
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/general-tools-1.2.0-1-linux.pkg.tar.xz"
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/gamecube-tools-1.0.2-1-linux.pkg.tar.xz"
+          
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/wii_rules"
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/base_tools"
+          wget "https://patcher.rc24.xyz/update/Mail-Patcher/base_rules"
+          
+          cd ..
+      - name: Extract devkitPPC r37, libogc, general-tools and gamecube-tools
+        run: | 
+          tar -xf cache/devkitPPC-r37-4-linux.pkg.tar.xz opt/devkitpro/devkitPPC --strip-components=1
+          tar -xf cache/libogc-2.1.0-1-any.pkg.tar.xz opt/devkitpro/libogc --strip-components=1
+          tar -xf cache/general-tools-1.2.0-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/bin2s --strip-components=4
+          sudo cp bin2s /usr/local/bin/bin2s
+          tar -xf cache/gamecube-tools-1.0.2-1-linux.pkg.tar.xz opt/devkitpro/tools/bin/elf2dol --strip-components=4
+          sudo cp elf2dol /usr/local/bin/elf2dol
+          
+          cp cache/wii_rules /home/runner/work/Mail-Patcher/Mail-Patcher/devkitpro/devkitPPC/wii_rules
+          cp cache/base_tools /home/runner/work/Mail-Patcher/Mail-Patcher/devkitpro/devkitPPC/base_tools
+          cp cache/base_rules /home/runner/work/Mail-Patcher/Mail-Patcher/devkitpro/devkitPPC/base_rules
+      - name: Compile
+        run: |
+          PATH=$(pwd)/devkitpro/devkitPPC/bin:$PATH DEVKITPPC=$(pwd)/devkitpro/devkitPPC DEVKITPRO=$(pwd)/devkitpro make
+      - name: Package
+        run: |
+          mkdir -p apps/Mail-Patcher/
+          cp Mail-Patcher.dol apps/Mail-Patcher/boot.dol
+          cp icon.png apps/Mail-Patcher/icon.png
+          cp meta.xml apps/Mail-Patcher/meta.xml
+      - name: Upload binaries
+        uses: actions/upload-artifact@v2
+        with: 
+          name: Mail-Patcher
+          path: |
+            apps
+            

--- a/source/config.h
+++ b/source/config.h
@@ -1,2 +1,2 @@
-#define BASE_HTTP_URL "mtw.rc24.xyz"
+#define BASE_HTTP_URL "mtwpatch.rc24.xyz"
 #define BASE_MAIL_URL "@rc24.xyz"

--- a/source/main.c
+++ b/source/main.c
@@ -47,6 +47,8 @@ int main(int argc, char** argv) {
         printf(":---------------------------------------------------------------:\n"
                ": Dolphin is not supported!                                     :\n"
                ": This tool can only run on a real Nintendo Wii Console.        :\n"
+               ":                                                               :\n"
+               ": Exiting in 5 seconds...                                       :\n"
                ":---------------------------------------------------------------:\n");
         sleep(5);
         exit(0);

--- a/source/main.c
+++ b/source/main.c
@@ -36,11 +36,12 @@ int main(int argc, char** argv) {
     VIDEO_WaitVSync();
     if (rmode->viTVMode & VI_NON_INTERLACE) VIDEO_WaitVSync();
 
-	printf("\n:------------------------------------------------:\n");
-	printf(": RiiConnect24 Mail Patcher - (C) Spotlight v1.3 :\n: Compiled on 2020/09/19 at 9:13PM               :\n");
-	printf(":------------------------------------------------:\n");
+	printf("\n:--------------------------------------------------:\n");
+	printf("  RiiConnect24 Mail Patcher - (C) Spotlight v1.3\n  Compiled on %s", __DATE__);
+	printf(" at %s\n", __TIME__);
+	printf(":--------------------------------------------------:\n\n");
 
-	printf("Connecting to the Internet... OK\n");
+	printf("Running...\n\n");
 
     if (isDolphin()) {
         printf(":---------------------------------------------------------------:\n"

--- a/source/main.c
+++ b/source/main.c
@@ -11,9 +11,6 @@
 #include "network.h"
 #include "patcher.h"
 
-#define textPos(x, y) printf("\x1b[%d;%dH", y, x)
-#define htons(x) (x)
-
 static void* xfb = NULL;
 static GXRModeObj* rmode = NULL;
 
@@ -36,28 +33,30 @@ int main(int argc, char** argv) {
     VIDEO_WaitVSync();
     if (rmode->viTVMode & VI_NON_INTERLACE) VIDEO_WaitVSync();
 
-	printf("\n:--------------------------------------------------:\n");
-	printf("  RiiConnect24 Mail Patcher - (C) Spotlight v1.3\n  Compiled on %s", __DATE__);
-	printf(" at %s\n", __TIME__);
-	printf(":--------------------------------------------------:\n\n");
+    printf("\n:------------------------------------------------:\n");
+    printf(": RiiConnect24 Mail Patcher - (C) Spotlight v1.3 :\n");
+    printf(": Compiled on " __DATE__ " at " __TIME__ "            :\n");
+    printf(":------------------------------------------------:\n");
 
 	printf("Running...\n\n");
 
     if (isDolphin()) {
-        printf(":---------------------------------------------------------------:\n"
-               ": Dolphin is not supported!                                     :\n"
-               ": This tool can only run on a real Nintendo Wii Console.        :\n"
-               ":                                                               :\n"
-               ": Exiting in 5 seconds...                                       :\n"
-               ":---------------------------------------------------------------:\n");
+        printf(":------------------------------------------------:\n"
+               ": Dolphin is not supported!                      :\n"
+               ": This tool can only run on a real               :\n"
+               ": Nintendo Wii Console.                          :\n"
+               ":                                                :\n"
+               ": Exiting in 5 seconds...                        :\n"
+               ":------------------------------------------------:\n");
         sleep(5);
         exit(0);
     } else if (CheckvWii()){
-        printf(":---------------------------------------------------------------:\n"
-               ": vWii Detected                                                 :\n"
-               ": This tool will still patch your nwc24msg.cfg, but you will be :\n"
-               ": Unable to fully utilize Wii mail                              :\n" 
-               ":---------------------------------------------------------------:\n");
+        printf(":------------------------------------------------:\n"
+               ": vWii Detected                                  :\n"
+               ": This tool will still patch your nwc24msg.cfg,  :\n"
+               ": but you will be unable to                      :\n"
+               ": fully utilize Wii mail                         :\n"
+               ":------------------------------------------------:\n");
     }
     printf("\nPatching...\n\n");
 

--- a/source/network.c
+++ b/source/network.c
@@ -4,7 +4,7 @@
 s32 doRequest(const void* hostname, const void* path, const u16 port, void* buffer, u32 length, const char* requestType) {
     s32 error = net_get_status();
     if (error < 0) {
-        printf("net_get_status: %li\n", error);
+        printf("net_get_status: %i\n", error);
         return error;
     }
 
@@ -38,21 +38,21 @@ Cache-Control: no-cache\r\n\r\n%s",
     if (port == 443) {
         error = ssl_init();
         if (error < 0) {
-            printf("ssl_init: error %li", error);
+            printf("ssl_init: error %i", error);
             net_close(sock);
             return error;
         }
 
         s32 sslContext = ssl_new((u8*)hostname, 0);
         if (sslContext < 0) {
-            printf("ssl_new: error %li\n", error);
+            printf("ssl_new: error %i\n", error);
             net_close(sock);
             return error;
         }
 
         error = ssl_setbuiltinclientcert(sslContext, 0);
         if (error < 0) {
-            printf("ssl_setbuiltinclientcert: error %li\n", error);
+            printf("ssl_setbuiltinclientcert: error %i\n", error);
             ssl_shutdown(sslContext);
             net_close(sock);
             return error;
@@ -60,7 +60,7 @@ Cache-Control: no-cache\r\n\r\n%s",
 
         error = ssl_connect(sslContext, sock);
         if (error < 0) {
-            printf("ssl_connect: error %li\n", error);
+            printf("ssl_connect: error %i\n", error);
             ssl_shutdown(sslContext);
             net_close(sock);
             return error;
@@ -68,7 +68,7 @@ Cache-Control: no-cache\r\n\r\n%s",
 
         error = ssl_handshake(sslContext);
         if (error < 0) {
-            printf("ssl_handshake: error %li\n", error);
+            printf("ssl_handshake: error %i\n", error);
             ssl_shutdown(sslContext);
             net_close(sock);
             return error;
@@ -76,7 +76,7 @@ Cache-Control: no-cache\r\n\r\n%s",
 
         error = ssl_write(sslContext, request, sizeof(request));
         if (error < 0) {
-            printf("ssl_write: error %li\n", error);
+            printf("ssl_write: error %i\n", error);
             ssl_shutdown(sslContext);
             net_close(sock);
             return error;
@@ -84,7 +84,7 @@ Cache-Control: no-cache\r\n\r\n%s",
 
         error = ssl_read(sslContext, response, length);
         if (error < 0) {
-            printf("ssl_read: error %li\n", error);
+            printf("ssl_read: error %i\n", error);
             ssl_shutdown(sslContext);
             net_close(sock);
             return error;
@@ -94,14 +94,14 @@ Cache-Control: no-cache\r\n\r\n%s",
     } else {
         error = net_send(sock, request, sizeof(request), 0);
         if (error < 0) {
-            printf("net_send: error %li\n", error);
+            printf("net_send: error %i\n", error);
             net_close(sock);
             return error;
         }
 
         error = net_recv(sock, response, length, 0);
         if (error < 0) {
-            printf("net_recv: error %li\n", error);
+            printf("net_recv: error %i\n", error);
             net_close(sock);
             return error;
         }


### PR DESCRIPTION
Self explanatory title, changing the %li passed to printf to %i to fix the compiler warnings

```
/home/peter/Documents/Mail-Patcher/source/network.c:104:39: warning: format '%li' expects argument of type 'long int', but argument 2 has type 's32' {aka 'int'} [-Wformat=]
  104 |             printf("net_recv: error %li\n", error);
      |                                     ~~^     ~~~~~
      |                                       |     |
      |                                       |     s32 {aka int}
      |                                       long int
      |                                     %i
patcher.c
/home/peter/Documents/Mail-Patcher/source/patcher.c: In function 'patchMail':
/home/peter/Documents/Mail-Patcher/source/patcher.c:169:47: warning: format '%li' expects argument of type 'long int', but argument 2 has type 's32' {aka 'int'} [-Wformat=]
  169 |         printf(" Couldn't request the data: %li\n", error);
      |                                             ~~^     ~~~~~
      |                                               |     |
      |                                               |     s32 {aka int}
      |                                               long int
      |                                             %i
```